### PR TITLE
[semver:patch] Upgrade default to Super-Linter v4

### DIFF
--- a/src/examples/lint-code-with-options.yml
+++ b/src/examples/lint-code-with-options.yml
@@ -9,6 +9,6 @@ usage:
     lint-code:
       jobs:
         - github-super-linter/lint:
-            version: "v3" # The Docker image version tag
+            version: "v4" # The Docker image version tag
             scan-dir: "src" # The directory to scan
             context: Super-Linter-Options # A CircleCI Context containing environment variables

--- a/src/examples/lint-code-with-options.yml
+++ b/src/examples/lint-code-with-options.yml
@@ -6,7 +6,7 @@ usage:
   orbs:
     github-super-linter: circleci/github-super-linter@1.0
   workflows:
-    lint-code:
+    lint-code-with-options:
       jobs:
         - github-super-linter/lint:
             version: "v4" # The Docker image version tag

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -9,7 +9,7 @@ docker:
 parameters:
   version:
     type: string
-    default: v3
+    default: v4
     description: |
       Pick a specific github/super-linter tag:
       https://hub.docker.com/r/github/super-linter/tags


### PR DESCRIPTION
This PR,

* fixes the default GitHub Super-Linter version, working around a bug preventing this orb from working out of the box.
* fixes a typo in one of the examples

Out of the box, I could not get this orb to work. I immediately got this error:

> /action/lib/linter.sh: line 57: /action/lib/functions/tapLibrary.sh: No such file or directory

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/33203301/151286709-218a4022-c5c8-4118-8681-e17d3f8f85a9.png">

This was previously reported in superlinter via https://github.com/github/super-linter/issues/2253 and fixed, but with many users including the key developer @admiralawkbar (who I'm working with on other work; hi 👋🏻 😁 ) suggesting to move to v4 which came out around May 2021.

So this changes to the default, and right off the bat using v4 for me works:

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/33203301/151287121-99910bd7-e43c-44af-9469-f0b23d504d2a.png">

Hello trash panda 🐼 , my little friend.

I marked this as a patch update, even though it moves the dependency up a major. Welcome to be corrected there!

Realized this also closes #3.
