### PR TITLE
[semver:skip] Recommend latest orb version to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simply add the `github-super-linter/lint` job to your new or existing config.
 ```yaml
 version: 2.1
 orbs:
-    github-super-linter: circleci/github-super-linter@1.0
+    github-super-linter: circleci/github-super-linter@1.0.1
 workflows:
     lint-code:
         jobs:

--- a/src/examples/lint-code-with-options.yml
+++ b/src/examples/lint-code-with-options.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    github-super-linter: circleci/github-super-linter@1.0
+    github-super-linter: circleci/github-super-linter@1.0.1
   workflows:
     lint-code-with-options:
       jobs:

--- a/src/examples/lint-code.yml
+++ b/src/examples/lint-code.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    github-super-linter: circleci/github-super-linter@1.0
+    github-super-linter: circleci/github-super-linter@1.0.1
   workflows:
     lint-code:
       jobs:


### PR DESCRIPTION
In #4, we patched this orb to use the latest version of the orb to use by default a newer version of the GitHub SuperLinter which isn't broken.

I've found a few of my users copying this example in the README, which doesn't work until they notice there's a patch.

Updates the README and the examples.

This is a trivial change, and not suggesting long term this needs to be kept up to date necessarily, but for new users, getting the v1.0.1 of this orb will likely be the only way they can get it working - otherwise their experience may be less than ideal.