### PR TITLE
docs: Update orb registry page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ workflows:
 
 ## Resources
 
-[CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/circleci/GitHub-Super-Linter-Orb) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+[CircleCI Orb Registry Page](https://circleci.com/developer/orbs/orb/circleci/github-super-linter) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.
 
 ### How to Contribute


### PR DESCRIPTION
### Implementation Details :construction:

- Updated the orb registry page link, which was broken.